### PR TITLE
Added code to deal with extra "expver" dimension in ERA5T files

### DIFF
--- a/ECMWF_tools.py
+++ b/ECMWF_tools.py
@@ -157,7 +157,7 @@ class ECMWF_tools:
             "variable": [parameter],
             "format": "netcdf",
             "area": self.config_ecmwf.area,
-            "verbose": self.config_ecmwf.debug,
+#            "verbose": self.config_ecmwf.debug,
         }
 
         # Add more specific options for variables on pressure surfaces


### PR DESCRIPTION
For data < 3 months, some variables have en extra dimension "expver" that indicates which data are from ERA5 and from ERA5T (the latter will need to be updated with consolidated data). The code was failing due to this extra dimension, the atmospheric variable having double the size of the original one. When the dimension "expver" exists, the added code merges the ERA5 and ERA5T datasets and add a note in the attributes of the file.
This version of the code also comments out the line verbose: self.config_ecmwf.debug  in the file ECMWF_tools.py to avoid the "False is not of type string" error, as suggested by @crargr in issue #10 